### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "scripts": {
     "test": "./node_modules/.bin/mocha test/*.js"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/hokaccha/node-jwt-simple/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "engines": {"node": ">= 0.4.0"},
   "keywords": ["jwt", "encode", "decode"],
   "main": "./index"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/