### PR TITLE
Check for lack of token

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -56,6 +56,10 @@ jwt.version = '0.2.0';
  * @api public
  */
 jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
+  // check token
+  if (!token) {
+    throw new Error('No token supplied');
+  }
   // check segments
   var segments = token.split('.');
   if (segments.length !== 3) {


### PR DESCRIPTION
If no token is supplied to the decode function, token.split('.') will cause an error as it is trying to split undefined. There should be a check to ensure this doesn't happen and therefore doesn't crash the application.