### PR TITLE
bump version in the lib file

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -43,7 +43,7 @@ var jwt = module.exports;
 /**
  * version
  */
-jwt.version = '0.2.0';
+jwt.version = '0.4.0';
 
 /**
  * Decode jwt 


### PR DESCRIPTION
Hi,

I was looking at the lib file to understand a bug on my code, and noticed that `jwt.version` was out of sync (`0.2.0` instead of `0.4.0` now).

Sorry for this sort of lousy PR, but that's something =)