### PR TITLE
Add support for nbf and exp claims

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -82,6 +82,16 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
       throw new Error('Algorithm not supported');
     }
 
+    // Support for nbf and exp claims.
+    // According to the RFC, they should be in seconds.
+    if (payload.nbf && Date.now() < payload.nbf*1000) {
+      throw new Error('Token not yet active');
+    }
+
+    if (payload.exp && Date.now() > payload.exp*1000) {
+      throw new Error('Token expired');
+    }
+
     // verify signature. `sign` will return base64 string.
     var signingInput = [headerSeg, payloadSeg].join('.');
     if (!verify(signingInput, key, signingMethod, signingType, signatureSeg)) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -72,6 +72,20 @@ describe('decode', function() {
     expect(fn).to.throwError(/Signature verification failed/);
   });
 
+  it('throw an error when the token is not yet active (optional nbf claim)', function() {
+    var nbf = (Date.now() + 1000) / 1000;
+    var token = jwt.encode({ foo: 'bar', nbf: nbf }, key);
+    var fn = jwt.decode.bind(null, token, key);
+    expect(fn).to.throwError(/Token not yet active/);
+  });
+
+  it('throw an error when the token has expired (optional exp claim)', function() {
+    var exp = (Date.now() - 1000) / 1000;
+    var token = jwt.encode({ foo: 'bar', exp: exp }, key);
+    var fn = jwt.decode.bind(null, token, key);
+    expect(fn).to.throwError(/Token expired/);
+  });
+
   it('do not throw any error when verification is disabled', function() {
     var obj = { foo: 'bar' };
     var key = 'key';


### PR DESCRIPTION
Hi, here is a PR for [this issue (the nbf and exp claims)](https://github.com/hokaccha/node-jwt-simple/issues/8).

Before merging, I have a question : what purpose do you intend for the `noVerify` option ? Should it skip signature validation **and** the new `nbf` and `exp` claims, or only the signature validation ?

If we choose the latter, I will need a little refactor of this PR...

For me, both of these options sound valid in their own way.