### PR TITLE
Use strict equality check for "noVerify" when decoding

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -66,6 +66,12 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
     throw new Error('Not enough or too many segments');
   }
 
+  // check noVerify - only accept a boolean value for noVerify to avoid user error
+  var typeofNoVerify = typeof noVerify;
+  if (typeofNoVerify !== 'undefined' && typeofNoVerify !== 'boolean') {
+    throw new Error('Invalid optional "noVerify" argument. It must be a boolean');
+  }
+
   // All segment should be base64
   var headerSeg = segments[0];
   var payloadSeg = segments[1];
@@ -75,7 +81,7 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
   var header = JSON.parse(base64urlDecode(headerSeg));
   var payload = JSON.parse(base64urlDecode(payloadSeg));
 
-  if (!noVerify) {
+  if (noVerify !== true) {
     var signingMethod = algorithmMap[algorithm || header.alg];
     var signingType = typeMap[algorithm || header.alg];
     if (!signingMethod || !signingType) {


### PR DESCRIPTION
It would be safer if the "noVerify" argument to "decode" was required to be a "boolean". Otherwise you could have a scenario in which a user passes an algorithm string as the third parameter and decode skips verification.

What do you think?
