### PR TITLE
Move nbf and exp verifications after signature verification.

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -82,6 +82,12 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
       throw new Error('Algorithm not supported');
     }
 
+    // verify signature. `sign` will return base64 string.
+    var signingInput = [headerSeg, payloadSeg].join('.');
+    if (!verify(signingInput, key, signingMethod, signingType, signatureSeg)) {
+      throw new Error('Signature verification failed');
+    }
+
     // Support for nbf and exp claims.
     // According to the RFC, they should be in seconds.
     if (payload.nbf && Date.now() < payload.nbf*1000) {
@@ -90,12 +96,6 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
 
     if (payload.exp && Date.now() > payload.exp*1000) {
       throw new Error('Token expired');
-    }
-
-    // verify signature. `sign` will return base64 string.
-    var signingInput = [headerSeg, payloadSeg].join('.');
-    if (!verify(signingInput, key, signingMethod, signingType, signatureSeg)) {
-      throw new Error('Signature verification failed');
     }
   }
 

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -43,7 +43,7 @@ var jwt = module.exports;
 /**
  * version
  */
-jwt.version = '0.5.0';
+jwt.version = '0.5.1';
 
 /**
  * Decode jwt

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jwt-simple",
   "description": "JWT(JSON Web Token) encode and decode module",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Kazuhito Hokamura <k.hokamura@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi,

I would like to move the signature validation before the check of `exp` and `nbf` claims.

I have the following scenario, which I believe is quite common: I sign tokens with an expiration date, but I want my system to be able to refresh them (i.e. re-emit a new one with the data of the old one, but with a later expiration date) if the expiration date was near AND **the token passed validation**. Currently I can't, because an expiration error will be thrown *before* the actual validation.

To do that, we need the token to be validated first, and then its expiration checked. People that don't want to use expiration, can just opt-out and not put any `exp` flag, as usual. This should not change anything for the rest of the users, and allow a new interesting use case.

Please tell me if there is an issue I did not think of.