### PR TITLE
 - fixed a bug related to token active/expire time checking conditions

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -90,11 +90,11 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
 
     // Support for nbf and exp claims.
     // According to the RFC, they should be in seconds.
-    if (payload.nbf && Date.now() < payload.nbf*1000) {
+    if (payload.nbf && Date.now() < payload.nbf*1) {
       throw new Error('Token not yet active');
     }
 
-    if (payload.exp && Date.now() > payload.exp*1000) {
+    if (payload.exp && Date.now() > payload.exp*1) {
       throw new Error('Token expired');
     }
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -73,14 +73,14 @@ describe('decode', function() {
   });
 
   it('throw an error when the token is not yet active (optional nbf claim)', function() {
-    var nbf = (Date.now() + 1000) / 1000;
+    var nbf = (Date.now() + 1000);
     var token = jwt.encode({ foo: 'bar', nbf: nbf }, key);
     var fn = jwt.decode.bind(null, token, key);
     expect(fn).to.throwError(/Token not yet active/);
   });
 
   it('throw an error when the token has expired (optional exp claim)', function() {
-    var exp = (Date.now() - 1000) / 1000;
+    var exp = (Date.now() - 1000);
     var token = jwt.encode({ foo: 'bar', exp: exp }, key);
     var fn = jwt.decode.bind(null, token, key);
     expect(fn).to.throwError(/Token expired/);


### PR DESCRIPTION
In jwt.js file at line **93 & 97**, multiplication is done by 1000 it should be by 1, because in javascript Date.now() function always return in millisecond and if you multiply it with 1000 then it will change the overall value like this bellow
 
 `new Date((Date.now()))`  returns _Fri Dec 30 2016 12:06:40 GMT+0530 (IST)_ and 
 `new Date((Date.now() *1000))`  returns _Fri Dec 05 48966 19:13:48 GMT+0530 (IST)_  after conversion.

  so i'm requesting you please validate my point above, 