### PR TITLE
Add crypto to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4"
   },
+  "dependencies": {
+    "crypto": "0.0.3"
+  },
   "scripts": {
     "test": "istanbul cover _mocha test/*.js"
   },


### PR DESCRIPTION
The package doesn't contain the needed libraries to actually be used. This fixes that.