### PR TITLE
Fix chrome override

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -10,7 +10,7 @@
 /**
  * module dependencies
  */
-var crypto = require('crypto-browserify');
+var crypt = require('crypto-browserify');
 
 
 /**
@@ -162,7 +162,7 @@ function verify(input, key, method, type, signature) {
     return (signature === sign(input, key, method, type));
   }
   else if(type == "sign") {
-    return crypto.createVerify(method)
+    return crypt.createVerify(method)
                  .update(input)
                  .verify(key, base64urlUnescape(signature), 'base64');
   }
@@ -174,10 +174,10 @@ function verify(input, key, method, type, signature) {
 function sign(input, key, method, type) {
   var base64str;
   if(type === "hmac") {
-    base64str = crypto.createHmac(method, key).update(input).digest('base64');
+    base64str = crypt.createHmac(method, key).update(input).digest('base64');
   }
   else if(type == "sign") {
-    base64str = crypto.createSign(method).update(input).sign(key, 'base64');
+    base64str = crypt.createSign(method).update(input).sign(key, 'base64');
   }
   else {
     throw new Error('Algorithm type not recognized');

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -10,7 +10,7 @@
 /**
  * module dependencies
  */
-var crypto = require('crypto');
+var crypto = require('crypto-browserify');
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "http://github.com/hokaccha/node-jwt-simple.git"
   },
+  "dependencies": {
+    "crypto-browserify": "^3.11.0"
+  },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",


### PR DESCRIPTION
It didn't work in the browser, because Chrome overwrote the `crypto` lib. This makes it use a different library for `crypto` that *does* work in the browser. I also changed the variable name because of chrome overriding things