### PR TITLE
Mark "noVerify" and "algorithm" as optional in jsdoc

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -50,8 +50,8 @@ jwt.version = '0.5.1';
  *
  * @param {Object} token
  * @param {String} key
- * @param {Boolean} noVerify
- * @param {String} algorithm
+ * @param {Boolean} [noVerify]
+ * @param {String} [algorithm]
  * @return {Object} payload
  * @api public
  */


### PR DESCRIPTION
Without it some IDE/editors show message "Invalid number of arguments, expected 4" when using
```js
jwt.decode(token, secret)
```