### PR TITLE
add capacity to decode by header-specified kid

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ console.log(decoded); //=> { foo: 'bar' }
 
 ```javascript
 /*
- * jwt.decode(token, key, noVerify, algorithm)
+ * jwt.decode(token, keyOrKeys, noVerify, algorithm)
  */
 
 // decode, by default the signature of the token is verified
@@ -43,6 +43,17 @@ console.log(decoded); //=> { foo: 'bar' }
 
 // decode with a specific algorithm (not using the algorithm described in the token payload)
 var decoded = jwt.decode(token, secret, false, 'HS256');
+console.log(decoded); //=> { foo: 'bar' }
+
+// decode when the token specifies a key id,
+// e.g. token header contains { kid: 'keyId1' }
+// and was encrypted with the key for 'secret'.
+var keys = {
+    keyId1: secret,
+    keyId2: someOtherSecret
+    //..
+}
+var decoded = jwt.decode(token, keys);
 console.log(decoded); //=> { foo: 'bar' }
 ```
 

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -82,6 +82,10 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
       throw new Error('Algorithm not supported');
     }
 
+    if (key[header.kid]) {
+      key = key[header.kid];
+    }
+
     // verify signature. `sign` will return base64 string.
     var signingInput = [headerSeg, payloadSeg].join('.');
     if (!verify(signingInput, key, signingMethod, signingType, signatureSeg)) {
@@ -107,7 +111,7 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
  * Encode jwt
  *
  * @param {Object} payload
- * @param {String} key
+ * @param {String|{[kid: String]: String}} key
  * @param {String} algorithm
  * @param {Object} options
  * @return {String} token

--- a/test/basic.js
+++ b/test/basic.js
@@ -132,6 +132,14 @@ describe('decode', function() {
       var obj2 = jwt.decode(token, cert);
       expect(jwt.decode.bind(null, token, 'invalid_key')).to.throwError();
     });
+
+    it('decode token when header specifies a kid', function() {
+      var token = jwt.encode(obj, pem, alg, {header: {kid: 'myKey'}});
+      var obj2 = jwt.decode(token, {myKey:cert});
+      expect(obj2).to.eql(obj);
+      expect(jwt.decode.bind(null, token, {notMyKey:cert})).to.throwError();
+      expect(jwt.decode.bind(null, token, {myKey:'invalid_key'})).to.throwError();
+    })
   });
 });
 


### PR DESCRIPTION
The JWT header parameter `kid` can specify a key id with which the token should be verified. ([JWT Spec](https://tools.ietf.org/html/rfc7515#section-4.1.4)). This PR adds this functionality to the library, by allowing the `key` parameter to `decode` to take a dictionary of `{[keyId]: key}`, and allowing the `kid` parameter of `header` to specify which key to decode with.

For example, if the header of `token` looks like
```js
{ alg: 'RS256', kid: 'keyId123' }
```
then
```js
jwt.decode(token, {keyId123: secret})
```
is equivalent to
```js
jwt.decode(token, secret)
```
.

This is useful for interacting with third party JWT issuers, for example AWS Cognito. With these, you do not necessarily know which secret will be used to sign a token in advance. The only way to use these services with this library currently is
```js
var header = JSON.parse(new Buffer(token.split('.')[0], 'base64').toString()) // can't get header with jwt-simple
var keys = getKeys() // say this returns { key1: 'key...', key2: 'key2...' }
var token = jwt.decode(token, keys[header.kid]);
```

## Caveats
The `kid` parameter will generally refer to a key specified in an array of JWKs, which look like [this](https://tools.ietf.org/html/rfc7517#section-3). It's possible you might want the `keys` parameter to take an array of `JWK`s instead of the dictionary of `{[kid]:key}`. IMO it's not worth the complexity, but if you want me to change it to work like this then I can do that. Note however that this would add dependencies to this module as the conversion from JWK to pem is non-trivial.