### PR TITLE
Excludes `coverage/` in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .vimrc*
 .git*
 .travis.yml
+coverage

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+Excludes `coverage/` in .npmignore
+
 ## 0.5.3
 
 Security fix #86

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-jwt-simple
+# jwt-simple
 
 [JWT(JSON Web Token)](http://self-issued.info/docs/draft-jones-json-web-token.html) encode and decode module for node.js.
 

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -43,7 +43,7 @@ var jwt = module.exports;
 /**
  * version
  */
-jwt.version = '0.5.3';
+jwt.version = '0.5.4';
 
 /**
  * Decode jwt

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jwt-simple",
   "description": "JWT(JSON Web Token) encode and decode module",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "Kazuhito Hokamura <k.hokamura@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Love how lightweight and simple this is!

Was looking at this project closer and notice that the repo is 15KB, but the node module is 91KB due to the included `coverage` dir.

Looks like a simple oversight, so just adding `coverage` to `.npmignore`.

📈🌈💕