### PR TITLE
Remove usage of deprecated Buffer constructor

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -191,7 +191,7 @@ function sign(input, key, method, type) {
 }
 
 function base64urlDecode(str) {
-  return new Buffer(base64urlUnescape(str), 'base64').toString();
+  return Buffer.from(base64urlUnescape(str), 'base64').toString();
 }
 
 function base64urlUnescape(str) {
@@ -200,7 +200,7 @@ function base64urlUnescape(str) {
 }
 
 function base64urlEncode(str) {
-  return base64urlEscape(new Buffer(str).toString('base64'));
+  return base64urlEscape(Buffer.from(str).toString('base64'));
 }
 
 function base64urlEscape(str) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -136,7 +136,7 @@ describe('decode', function() {
 });
 
 function base64urlDecode(str) {
-  return new Buffer(base64urlUnescape(str), 'base64').toString();
+  return Buffer.from(base64urlUnescape(str), 'base64').toString();
 }
 
 function base64urlUnescape(str) {


### PR DESCRIPTION
The use of `new Buffer()` has been deprecated in favor of `Buffer.from/alloc`, according to: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

This pull request replaces all relevant calls with the new methods, including the test.