### PR TITLE
Add payload to decode thrown errors

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -83,23 +83,23 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
     var signingMethod = algorithmMap[algorithm || header.alg];
     var signingType = typeMap[algorithm || header.alg];
     if (!signingMethod || !signingType) {
-      throw new Error('Algorithm not supported');
+      throw addPayload(new Error('Algorithm not supported'), payload);
     }
 
     // verify signature. `sign` will return base64 string.
     var signingInput = [headerSeg, payloadSeg].join('.');
     if (!verify(signingInput, key, signingMethod, signingType, signatureSeg)) {
-      throw new Error('Signature verification failed');
+      throw addPayload(new Error('Signature verification failed'), payload);
     }
 
     // Support for nbf and exp claims.
     // According to the RFC, they should be in seconds.
     if (payload.nbf && Date.now() < payload.nbf*1000) {
-      throw new Error('Token not yet active');
+      throw addPayload(new Error('Token not yet active'), payload);
     }
 
     if (payload.exp && Date.now() > payload.exp*1000) {
-      throw new Error('Token expired');
+      throw addPayload(new Error('Token expired'), payload);
     }
   }
 
@@ -205,4 +205,9 @@ function base64urlEncode(str) {
 
 function base64urlEscape(str) {
   return str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function addPayload(error, payload) {
+  error.payload = payload
+  return error
 }


### PR DESCRIPTION
I wanted to be able to use payload from a expired token, here i have to re-decode it, so i tought it wouldn't cost much to pass it along side the error