### PR TITLE
Add Buffer and KeyObject as possible key types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,13 @@
+import { KeyLike } from 'crypto';
+
 export type TAlgorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256';
 
 export interface IOptions {
   header: any;
 }
 
-export function decode(token: string, key: string, noVerify?: boolean, algorithm?: TAlgorithm): any;
+export function decode(token: string, key: string | Buffer, noVerify?: boolean, algorithm?: TAlgorithm): any;
+export function decode(token: string, key: KeyLike, noVerify: true): any;
+export function decode(token: string, key: KeyLike, noVerify: boolean, algorithm: TAlgorithm): any;
 
-export function encode(payload: any, key: string, algorithm?: TAlgorithm, options?: IOptions): string;
+export function encode(payload: any, key: KeyLike, algorithm?: TAlgorithm, options?: IOptions): string;


### PR DESCRIPTION
Fixes #97

This adds `Buffer` and `KeyObject` as possible parameter types for `key`.

`decode` gets multiple overloads to detect when the branch https://github.com/hokaccha/node-jwt-simple/blob/c58bfe5e5bb049015fcd55be5fc1b2d5c652dbcd/lib/jwt.js#L79 is triggered (if it is triggered, the key must be a `string` or `Buffer`; otherwise it can also be a `KeyObject`)

If that check were updated to be `KeyObject`-aware (see [KeyObject.asymmetricKeyType](https://nodejs.org/api/crypto.html#crypto_keyobject_asymmetrickeytype)), the `decode` types could be simplified to a single declaration:

```typescript
export function decode(token: string, key: KeyLike, noVerify?: boolean, algorithm?: TAlgorithm): any;
```