### PR TITLE
Allow the key type to be a Buffer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,6 @@ export interface IOptions {
   header: any;
 }
 
-export function decode(token: string, key: string, noVerify?: boolean, algorithm?: TAlgorithm): any;
+export function decode(token: string, key: string | Buffer, noVerify?: boolean, algorithm?: TAlgorithm): any;
 
-export function encode(payload: any, key: string, algorithm?: TAlgorithm, options?: IOptions): string;
+export function encode(payload: any, key: string | Buffer, algorithm?: TAlgorithm, options?: IOptions): string;


### PR DESCRIPTION
The underlying code doesn't really care; I've been running with these scissors for several months in a private patch.  Allowing a Buffer through allows for some more clever ways of handling the key - for instance being able to wipe the memory used by that buffer after it's done, or passing in other kinds of keys: whatever the [underlying crypto](https://nodejs.org/api/crypto.html#crypto_crypto_createhmac_algorithm_key_options) handles.